### PR TITLE
Missing command for installing mono

### DIFF
--- a/input/docs/linux.md
+++ b/input/docs/linux.md
@@ -21,9 +21,9 @@ MatterControl requires the latest version of Mono in order to work. Although Mon
 ```
 $ sudo apt install gnupg ca-certificates
 $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-$echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+$ echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
 $ sudo apt update
-
+$ sudo apt install mono-devel
 ```
 
 There are also instructions for other distributions on the [Mono website](https://www.mono-project.com/download/stable/).


### PR DESCRIPTION
Added " sudo apt install mono-devel " to Debian install process.